### PR TITLE
Execute Main.java not Game.java in testRun method to align test with the assignment specification

### DIFF
--- a/src/LCTest.java
+++ b/src/LCTest.java
@@ -213,7 +213,7 @@ public class LCTest {
 	int testRun(int gameCount) throws IOException, InterruptedException, TestException {
 		System.out.println("Running application... ");
 		int warnings = 0;
-		Process p = exec("java", "-cp", "bin", "Game");
+		Process p = exec("java", "-cp", "bin", "Main");
 
 		for (int i = 1; i <= gameCount; i++) {
 			if (p.waitFor(500, TimeUnit.MILLISECONDS)) {


### PR DESCRIPTION
The entry point of the LuckyCard applications is the Main.java file according to the assignment specifications, the testRun method is trying to run Game.java as the entry point:

```
class Main {
   public static void main(String[] args) {
      ...
   }
}
```